### PR TITLE
Fix user-specific project filtering

### DIFF
--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,17 +1,26 @@
 import { supabase } from '$lib/supabaseClient'
 import { error } from '@sveltejs/kit'
 
-export async function load({ depends }) {
+export async function load({ depends, locals }) {
   depends('app:projects')
 
+  const user = locals.session?.user
+  if (!user) {
+    return { activeProjects: [], doneProjects: [] }
+  }
+
   const [active, done] = await Promise.all([
-    supabase.from('projects')
+    supabase
+      .from('projects')
       .select('*')
+      .eq('user_id', user.id)
       .eq('done', false)
       .order('created_at', { ascending: false }),
 
-    supabase.from('projects')
+    supabase
+      .from('projects')
       .select('*')
+      .eq('user_id', user.id)
       .eq('done', true)
       .order('created_at', { ascending: false })
   ])


### PR DESCRIPTION
## Summary
- filter dashboard projects by user session on the server

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400cdaa1e48332b02addb71648afe9